### PR TITLE
add support of optional Special:MyLanguage for wiki links

### DIFF
--- a/wikilinksbot.py
+++ b/wikilinksbot.py
@@ -157,7 +157,7 @@ def linkformatter(link, conf):
     if (link[-1] == "|" or link[-1] == "]") and conf["toggle_normallinks"]: # Is this a normal [[wiki link]]?
         link = re.sub(r"[\[\]\|]", "", display)
         display = "&#91;&#91;" + link + "&#93;&#93;" # HTML-escaped [[link]]
-        url = conf["normallinks"] + "wiki/" + ("Special:MyLanguage/" if conf["toggle_mylanguage"] else "") + link.replace(" ", "_") # Replaces spaces with underscores
+        url = conf["normallinks"] + "wiki/" + ("Special:MyLanguage/" if conf["toggle_mylanguage"] and not link.startswith("Special:") else "") + link.replace(" ", "_") # Replaces spaces with underscores
         redirect = resolveredirect(link, conf["normallinks"]) # Check if the link is actually a redirect
         if redirect:
             url = conf["normallinks"] + "wiki/" + redirect.replace(" ", "_") # Link to the redirect target instead

--- a/wikilinksbot.py
+++ b/wikilinksbot.py
@@ -157,7 +157,7 @@ def linkformatter(link, conf):
     if (link[-1] == "|" or link[-1] == "]") and conf["toggle_normallinks"]: # Is this a normal [[wiki link]]?
         link = re.sub(r"[\[\]\|]", "", display)
         display = "&#91;&#91;" + link + "&#93;&#93;" # HTML-escaped [[link]]
-        url = conf["normallinks"] + "wiki/" + link.replace(" ", "_") # Replaces spaces with underscores
+        url = conf["normallinks"] + "wiki/" + ("Special:MyLanguage/" if conf["toggle_mylanguage"] else "") + link.replace(" ", "_") # Replaces spaces with underscores
         redirect = resolveredirect(link, conf["normallinks"]) # Check if the link is actually a redirect
         if redirect:
             url = conf["normallinks"] + "wiki/" + redirect.replace(" ", "_") # Link to the redirect target instead
@@ -217,6 +217,7 @@ def getconfig(chat_id):
         "toggle_normallinks": True,
         "toggle_wikibaselinks": True,
         "toggle_phabricator": False,
+        "toggle_mylanguage": False,
         "language": "en"
     }
     with open("group_settings.json", "r") as settings:
@@ -264,7 +265,7 @@ def config(update, context):
             update.message.reply_text(text=messages["setwiki_error"], parse_mode="html")
     elif command == "/toggle" and len(message) >= 3:
         option = "toggle_" + message[1]
-        options = {"toggle_normallinks": "normal [[wiki links]]", "toggle_wikibaselinks": "Wikibase entity links", "toggle_phabricator": "Phabricator links"}
+        options = {"toggle_normallinks": "normal [[wiki links]]", "toggle_wikibaselinks": "Wikibase entity links", "toggle_phabricator": "Phabricator links", "toggle_mylanguage": "Special:MyLanguage for [[wiki links]]"}
         toggle = message[2]
         toggles = {"on": True, "off": False}
         if option in options and toggle in ["on", "off"]:
@@ -314,6 +315,7 @@ def config(update, context):
             "toggle_normallinks": "Normal links are toggled {}",
             "toggle_wikibaselinks": "Wikibase links are toggled {}",
             "toggle_phabricator": "Phabricator links are toggled {}",
+            "toggle_mylanguage": "Special:MyLanguage for links are toggled {}",
             "language": "The language priority list for labels is {}"
         }
         configlist = ["The following is the bot configuration for this chat. Settings in <b>bold</b> are different from the default setting.\n"]


### PR DESCRIPTION
Especially non-English groups more interested in the wiki links than the wikibase links could benefit links to their native or user interface language. This would add a toggle for an option `mylanguage` that would if enabled add `Special:MyLanguage/` to the wiki links.